### PR TITLE
Typos and minor grammar fixes

### DIFF
--- a/workshops/arm/arm-lab1-basics.md
+++ b/workshops/arm/arm-lab1-basics.md
@@ -183,7 +183,7 @@ It will be more useful if we can specify that storage account name as a user par
    * Use CTRL-SPACE to bring up the snippets
 1. Change the name to 'storageAccount'
 1. Select the unique storage account resource name
-1. Press CTRL-F2 to select both occurences (as per the status bar)
+1. Press CTRL-F2 to select both occurrences (as per the status bar)
 1. Replace them with `[parameters('storageAccount')]`
 1. Save the template
 
@@ -240,7 +240,7 @@ Note that the parameter type is from a fixed list:
 * secureObject
 * array
 
-Strings, integers and booleans (true\|false) are self explanatory.
+Strings, integers and booleans (true\|false) are self-explanatory.
 
 The arrays and objects are the standard JSON constructs, and allow for more complex nested parameters to be defined.
 
@@ -293,20 +293,20 @@ Once you have updated the template then it should look similar to this:
 
 I have also updated the cosmetic descriptions for the two parameters.
 
-As you start adding to your ARM templates you will find that vscode has a couple of useful features as shown in the screenshot below.
+As you start adding to your ARM templates you will find that VS Code has a couple of useful features as shown in the screenshot below.
 
 ![JSON Outline](/workshops/arm/images/jsonoutline.png)
 
 1. In the Explorer (CTRL+SHIFT+E) on the left, you should see a JSON Outline, which is useful for navigating your template, highlighting a section of it and confirming that syntactically it is looking healthy.  If it does not look right in the JSON Outline then that would suggest that you have some braces in the wrong place.
 1. If you hover the cursor between the line numbers and the file contents then you'll see small `+` and `-` icons appear that you can use to shrink down the file.  This is useful for closing down sections of the templates that you know are healthy so that you can concentrate on new sections that may be causing you problems.  And again, if the lines that are opened and closed are not right then you need to check your braces.  I often close up existing parameters and resources when adding new ones to make sure that they are going in at the right point.
 
-Finally, the JSON Tools extension gives you a couple of new keyboard short cuts.  `ALT+M` will minify your JSON so that it takes up the minimum of space, and this may be useful later.  But for the moment the more useful is the `CTRL+ALT_+M` shortcut which pretty prints the JSON, cleaning up your indentation to make the template a little easier to read.
+Finally, the JSON Tools extension gives you a couple of new keyboard shortcuts.  `ALT+M` will minify your JSON so that it takes up the minimum amount of space, and this may be useful later.  But for the moment the more useful is the `CTRL+ALT+M` shortcut which pretty prints the JSON, cleaning up your indentation to make the template a little easier to read.
 
 Get used to using these as you move through the labs as it will save you some pain!
 
 ## Submitting with parameter specified inline
 
-OK, so we now have a couple of parameters in our template. We'll use the default value for the accountType. If we were to use the previous submission commands then we would be promted interactively for the parameter value.
+OK, so we now have a couple of parameters in our template. We'll use the default value for the accountType. If we were to use the previous submission commands then we would be prompted interactively for the parameter value.
 
 However we can specify the storage account name inline as we deploy, as per the commands below.  We'll also start using some variables to make the commands a little shorter and reusable.
 
@@ -345,7 +345,7 @@ The inline parameters for PowerShell deployments are very slick, and effectively
 
 ## Using variables
 
-OK, our template is now looking pretty good.  The major issue with it is that it does not ensure that the storageAccount will be unique and therefore the success of the deployment cannot be assured.  Let's fix that by using a variable and some of the functions that are available
+OK, our template is now looking pretty good.  The major issue with it is that it does not ensure that the storageAccount will be unique and therefore the success of the deployment cannot be assured.  Let's fix that by using a variable and some of the functions that are available.
 
 A quick search on "azure storage account naming conventions" takes us to the <a href="https://docs.microsoft.com/en-us/azure/architecture/best-practices/naming-conventions" target="docs">naming conventions</a> page in the best practices area.  The storage account name has to be lower case alphanumerics with 3-24 characters, and it recommends using a standard prefix.
 
@@ -361,7 +361,7 @@ Run through the following to modify your template:
     * We'll provide uniqueString with the subscriptionID as the seed
 1. For bonus points you can ensure the new variable will be in lower case
     * **toLower**: will lower case a string
-1. If we are going to concatenate the uniqueString with the prefix then we need to make sure we do not exceed 24 chars for the storageAccount, so we'll also put a maxLength restruction on the prefix parameter.
+1. If we are going to concatenate the uniqueString with the prefix then we need to make sure we do not exceed 24 chars for the storageAccount, so we'll also put a maxLength restriction on the prefix parameter.
 1. Finally we will reference the variable in the resources section.
 
 Take your time and work slowly through the steps one by one. This is the toughest part of this first lab, and intentionally so! Please avoid skipping ahead to check on the template at the end of this lab page.
@@ -378,7 +378,7 @@ If you finish earlier than others then explore the functions available.  Some of
 
 ## Testing template file validity
 
-As you get more complex with JSON templates, you will start to appreciate the intellisense that is built into VS Code and the Azure Resource Manager Tools extension.
+As you get into more complex JSON templates, you will start to appreciate the IntelliSense that is built into VS Code and the Azure Resource Manager Tools extension.
 
 Errors will be shown as wavy red underlines, and warnings will have yellow.  Hover over one of these and the tooltip will give good information on what needs to be addressed.
 
@@ -598,7 +598,7 @@ The arm-paramvalue snippet is designed to highlight the parameter name, so you c
 
 You can use the split editor mode in VS Code to see both files at the same time (use CTRL-ALT-LEFT or CTRL-ALT-RIGHT to move tabs between groups).  You can also save some screen estate by toggling the side bar (CTRL-B, or View \| Toggle Side Bar).
 
-Don't forget that the two parameters will need to seperated by a comma.  You will see a syntax error flagged up by VS Code until you do.
+Don't forget that the two parameters will need to separated by a comma.  You will see a syntax error flagged up by VS Code until you do.
 
 Once you have created your parameter file it should look similar to this:
 


### PR DESCRIPTION
E.g. missing full stops, hyphenation, capitalisation, typos on ‘restruction’, ‘promted’, ‘occurence’, ‘seperated’.