### PR TITLE
vnetName / virtualNetworkName inconsistency

### DIFF
--- a/workshops/arm/arm-lab3-secrets.md
+++ b/workshops/arm/arm-lab3-secrets.md
@@ -204,7 +204,7 @@ OK, we've addressed the password.  Let's start turning the template itself into 
 1. Change the publicIPAddressType variable to pipType
 1. Change the value for the vmSize variable to "Standard_B1s"
 
-In the parameters file, add in new virtualNetworkName and subnetName parameters and **remove** both vmName and dnsLabelPrefix. Here is an example:
+In the parameters file, add in new vnetName and subnetName parameters and **remove** both vmName and dnsLabelPrefix. Here is an example:
 
 ```json
 {
@@ -222,7 +222,7 @@ In the parameters file, add in new virtualNetworkName and subnetName parameters 
         "secretName": "ubuntuDefaultPassword"
       }
     },
-    "virtualNetworkName": {
+    "vnetName": {
         "value": "ubuntuVnet"
     },
     "subnetName": {


### PR DESCRIPTION
Text says ‘vnetName is replacing virtualNetworkName’, but ‘virtualNetworkName’ continues to be used for the rest of the example and in the provided files.