### PR TITLE
Terraform Lab4: Adding reserved=true for Linux app service plans

### DIFF
--- a/automation/terraform/lab4.md
+++ b/automation/terraform/lab4.md
@@ -106,6 +106,7 @@ resource "azurerm_app_service_plan" "free" {
     tags                = "${azurerm_resource_group.webapps.tags}"
 
     kind                = "Linux"
+    reserved            = true
     sku {
         tier = "Free"
         size = "F1"
@@ -195,6 +196,7 @@ resource "azurerm_app_service_plan" "free" {
     tags                = "${azurerm_resource_group.webapps.tags}"
 
     kind                = "Linux"
+    reserved            = true
     sku {
         tier = "Free"
         size = "F1"


### PR DESCRIPTION
Must add `reserved=true` for `Linux `app service plans while creating one, `reserved `defaults to `false `Reference - https://www.terraform.io/docs/providers/azurerm/r/app_service_plan.html